### PR TITLE
Fixes typo in example code in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ usage: mush [-ehV] [-f <file>] [-o <file>]
 examples:
   $ cat file.ms | FOO=BAR mush
   $ VALUE=123 mush -f file.ms -o file
-  $ echo "Today's date is {DATE}" | DATE=`date +%D` mush
+  $ echo "Today's date is {{DATE}}" | DATE=`date +%D` mush
   $ cat ./template.ms | VAR=VALUE mush
 
 options:


### PR DESCRIPTION
The example demonstrating piping a line directly to `mush` is missing a layer of brackets.

It reads `{DATE}` instead of `{{DATE}}`. This MR fixes that.